### PR TITLE
Bump pronto version to 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.2.2
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
 before_install: gem install bundler -v 1.10.6

--- a/pronto-rails_schema.gemspec
+++ b/pronto-rails_schema.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'pronto', '~> 0.6.0 '
+  spec.add_dependency 'pronto', '~> 0.7.0 '
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"

--- a/pronto-rails_schema.gemspec
+++ b/pronto-rails_schema.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_dependency 'pronto', '~> 0.7.0 '
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This pull request is to bump up the version of Pronto to 0.7.0 and above. Pronto was updated to version 0.7.0 a few weeks ago.

This runner is the only Pronto runner that I use that still hasn't bumped up their version, so hopefully this will encourage a gem update very soon :smile_cat: 
