### PR TITLE
Bump pronto dependency to 0.8.0

### DIFF
--- a/pronto-rails_schema.gemspec
+++ b/pronto-rails_schema.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'pronto', '~> 0.7.0 '
+  spec.add_dependency 'pronto', '~> 0.8.0 '
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"


### PR DESCRIPTION
This pull request is to bump up the version of Pronto to 0.7.0 and above. Pronto was updated to version 0.8.0 a few weeks ago, and subsequent updates contain a few fixes for bugs that affect this gem (for example, https://github.com/mmozuras/pronto/issues/201).

Updating the dependency version in the gemspec seems to be the only thing needed in my tests - please let me know if there's anything else needed for this change.