### PR TITLE
Add 'line' parameter to message to make Github formatter work 

### DIFF
--- a/lib/pronto/rails_schema.rb
+++ b/lib/pronto/rails_schema.rb
@@ -36,8 +36,9 @@ module Pronto
 
     def generate_messages_for(target)
       migration_patches.map do |patch|
-        Message.new(patch.delta.new_file[:path], nil, :warning,
-          "Migration file detected, but no changes in #{target}",
+        first_line = patch.added_lines.first
+        Message.new(patch.delta.new_file[:path], first_line, :warning,
+                  "Migration file detected, but no changes in #{target}",
           nil, self.class)
       end
     end

--- a/lib/pronto/rails_schema/version.rb
+++ b/lib/pronto/rails_schema/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module RailsSchemaVersion
-    VERSION = "0.9.0"
+    VERSION = "0.9.1"
   end
 end

--- a/spec/pronto/rails_schema_spec.rb
+++ b/spec/pronto/rails_schema_spec.rb
@@ -46,6 +46,11 @@ describe Pronto::RailsSchema do
         expect(subject.first.msg).to match(/Migration/)
       end
 
+      it 'adds warning message with line containing the commit_sha of migration file creation commit' do
+        expect(subject.first.line.content).to match(/class ThatMigration/)
+        expect(subject.first.line.commit_sha).to eq '4618a01a062aa18aeb205b250004acd1468a6867'
+      end
+
       context 'without schema file' do
         let(:schema_present) { false }
 


### PR DESCRIPTION
Github formatter needs the commit_sha in order to be able to post comments
currently, it simply fails.

This fixes that issue.

The json formatter now additionally outputs
{line: 1 and commit_sha: "752edcaa..."}