### PR TITLE
Update pronto-rails_schema.gemspec to recent pronto 0.11.0

### DIFF
--- a/pronto-rails_schema.gemspec
+++ b/pronto-rails_schema.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency 'pronto', '~> 0.10.0 '
+  spec.add_dependency 'pronto', '~> 0.11.0'
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"


### PR DESCRIPTION
While doing an upgrade to Rails 6.1 pronto 0.11.0 needed, which leads to this PR.